### PR TITLE
Improve game loading time

### DIFF
--- a/SkyboxPlugin/SkyboxList.cs
+++ b/SkyboxPlugin/SkyboxList.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using VRage.FileSystem;
 using VRage.Game;
 using VRage.ObjectBuilders;
@@ -30,11 +31,11 @@ namespace avaness.SkyboxPlugin
         {
             string workshop = Path.GetFullPath(@"..\..\..\workshop\content\244850\");
 
-            foreach (ulong id in SteamAPI.GetSubscribedWorkshopItems())
+            Parallel.ForEach(SteamAPI.GetSubscribedWorkshopItems(), (ulong id) =>
             {
                 string modPath = Path.Combine(workshop, id.ToString());
                 if (!Directory.Exists(modPath))
-                    continue;
+                    return;
 
                 if (Directory.Exists(Path.Combine(modPath, "Data")))
                 {
@@ -47,7 +48,7 @@ namespace avaness.SkyboxPlugin
                     if (legacyFile != null && TryGetLegacyFileDefinition(legacyFile, out MyObjectBuilder_EnvironmentDefinition definition))
                         skyboxes[id] = new Skybox(new WorkshopInfo(id, legacyFile), definition);
                 }
-            }
+            });
 
             SteamAPI.GetItemDetails(skyboxes.Keys, OnItemDetailsFound);
         }

--- a/SkyboxPlugin/SkyboxPlugin.csproj
+++ b/SkyboxPlugin/SkyboxPlugin.csproj
@@ -31,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Lib.Harmony.2.2.1\lib\net48\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.2.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Lib.Harmony.2.2.2\lib\net48\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="ProtoBuf.Net">
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\ProtoBuf.Net.dll</HintPath>

--- a/SkyboxPlugin/packages.config
+++ b/SkyboxPlugin/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Lib.Harmony" version="2.2.1" targetFramework="net48" />
+  <package id="Lib.Harmony" version="2.2.2" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Using parallel.foreach improved the load time by 45% on my machine (115s -> 63s) but only for the first game launch after restart (or after a long idle time) since the files are cached for subsequent launches.