### PR TITLE
Fix Skybox lighting

### DIFF
--- a/SkyboxPlugin/Skybox.cs
+++ b/SkyboxPlugin/Skybox.cs
@@ -27,7 +27,7 @@ namespace avaness.SkyboxPlugin
 
             def.EnvironmentTexture = ob.EnvironmentTexture;
             def.EnvironmentOrientation = ob.EnvironmentOrientation;
-            def.SunProperties = ob.SunProperties;
+            MySector.SunProperties = ob.SunProperties;
         }
 
         public override string ToString()


### PR DESCRIPTION
I recently noticed that skyboxes loaded by this plugin do not have their lighting properties loaded correctly. 
The lighting properties are assigned to MySector.SunProperties early in the game loading process, before the plugin's BeforeInit runs.
MyEnvironmentDefinition's SunProperties field isn't read after this happens, so the plugin assigning to this doesn't do anything.
By assigning to MySector.SunProperties instead, the skybox will appear the same as if it were loaded as part of the world.